### PR TITLE
Add legal pages (Privacy, Terms, Cookies, Disclaimer, Accessibility)

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Accessibility Statement for The ILS Network — our commitment to an accessible theILSnetwork.com.">
+  <meta property="og:title" content="Accessibility — The ILS Network">
+  <meta property="og:description" content="Our commitment to an accessible theILSnetwork.com.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://theILSnetwork.com/accessibility.html">
+  <title>Accessibility — The ILS Network</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- ═══ NAVIGATION ═══ -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <ul class="nav-links">
+        <li><a href="index.html#about">About</a></li>
+        <li><a href="index.html#pillars">What We Do</a></li>
+        <li><a href="index.html#network">The Network</a></li>
+        <li><a href="index.html#connect">Contact</a></li>
+      </ul>
+      <a href="index.html#connect" class="btn btn-primary nav-cta">Join Now</a>
+      <button class="hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+    <div class="mobile-menu" id="mobile-menu">
+      <a href="index.html#about">About</a>
+      <a href="index.html#pillars">What We Do</a>
+      <a href="index.html#network">The Network</a>
+      <a href="index.html#connect">Contact</a>
+      <a href="index.html#connect" class="btn btn-primary">Join Now</a>
+    </div>
+  </nav>
+
+  <!-- ═══ PAGE HEADER ═══ -->
+  <header class="page-header">
+    <div class="container">
+      <span class="eyebrow">Legal</span>
+      <h1>Accessibility</h1>
+      <p class="section-sub">Last updated: July 1, 2026</p>
+    </div>
+  </header>
+
+  <!-- ═══ ACCESSIBILITY CONTENT ═══ -->
+  <section class="section legal">
+    <div class="container">
+      <div class="legal-content fade-in">
+        <p>
+          The ILS Network is committed to making theILSnetwork.com (the "Site") usable by as many
+          people as possible, including people with disabilities.
+        </p>
+
+        <h2>1. Our Approach</h2>
+        <p>We aim to follow generally accepted accessibility practices in how the Site is built,
+          including:</p>
+        <ul>
+          <li>Semantic HTML structure and landmarks to support screen readers and assistive
+            technology;</li>
+          <li>Descriptive labels and <code>aria-label</code> attributes on interactive elements,
+            such as the navigation menu and social links;</li>
+          <li>Keyboard-operable navigation, including the mobile menu and contact form; and</li>
+          <li>Sufficient color contrast between text and background throughout the Site's design.</li>
+        </ul>
+
+        <h2>2. Ongoing Work</h2>
+        <p>Accessibility is an ongoing effort. As the Site evolves, we will continue reviewing pages
+          and features for usability across a range of devices, browsers, and assistive
+          technologies.</p>
+
+        <h2>3. Known Limitations</h2>
+        <p>Despite our efforts, some parts of the Site may not yet fully meet every accessibility
+          guideline. If you encounter a barrier, we want to know about it so we can address it.</p>
+
+        <h2>4. Feedback</h2>
+        <p>If you experience any difficulty accessing content or using any feature on the Site,
+          please let us know by emailing
+          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>. Please describe
+          the issue and the page where you encountered it so we can look into it.</p>
+
+        <h2>5. Changes to This Statement</h2>
+        <p>We may update this Accessibility Statement from time to time. The "Last updated" date at
+          the top of this page reflects the most recent revision.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FOOTER ═══ -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <p>Where vision meets community.</p>
+          <div class="social-links">
+            <a href="#" aria-label="LinkedIn" title="LinkedIn">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+            </a>
+            <a href="#" aria-label="X" title="X / Twitter">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="#" aria-label="Instagram" title="Instagram">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none"/></svg>
+            </a>
+            <a href="#" aria-label="YouTube" title="YouTube">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58A2.78 2.78 0 0 0 3.41 19.6C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z"/><polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" fill="white"/></svg>
+            </a>
+          </div>
+        </div>
+        <div class="footer-cols">
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="index.html#about">About</a></li>
+              <li><a href="index.html#pillars">What We Do</a></li>
+              <li><a href="index.html#network">The Network</a></li>
+              <li><a href="index.html#connect">Contact</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Community</h4>
+            <ul>
+              <li><a href="index.html#connect">Join the Network</a></li>
+              <li><a href="index.html#connect">Partner With Us</a></li>
+              <li><a href="index.html#connect">Media &amp; Press</a></li>
+              <li><a href="index.html#connect">Speaking Requests</a></li>
+              <li><a href="index.html#connect">Advertise</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="index.html#connect">Newsletter</a></li>
+              <li><a href="index.html#connect">Events</a></li>
+              <li><a href="index.html#connect">Podcast</a></li>
+              <li><a href="index.html#connect">Blog</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="privacy.html">Privacy Policy</a></li>
+              <li><a href="terms.html">Terms of Service</a></li>
+              <li><a href="cookies.html">Cookie Policy</a></li>
+              <li><a href="disclaimer.html">Disclaimer</a></li>
+              <li><a href="accessibility.html">Accessibility</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 The ILS Network. All rights reserved.</p>
+        <p>theILSnetwork.com</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/accessibility.html
+++ b/accessibility.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -97,7 +97,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/accessibility.html
+++ b/accessibility.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -97,7 +97,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/cookies.html
+++ b/cookies.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -99,7 +99,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/cookies.html
+++ b/cookies.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -99,7 +99,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/cookies.html
+++ b/cookies.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Cookie Policy for The ILS Network — what cookies and similar technologies are used on theILSnetwork.com.">
+  <meta property="og:title" content="Cookie Policy — The ILS Network">
+  <meta property="og:description" content="What cookies and similar technologies are used on theILSnetwork.com.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://theILSnetwork.com/cookies.html">
+  <title>Cookie Policy — The ILS Network</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- ═══ NAVIGATION ═══ -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <ul class="nav-links">
+        <li><a href="index.html#about">About</a></li>
+        <li><a href="index.html#pillars">What We Do</a></li>
+        <li><a href="index.html#network">The Network</a></li>
+        <li><a href="index.html#connect">Contact</a></li>
+      </ul>
+      <a href="index.html#connect" class="btn btn-primary nav-cta">Join Now</a>
+      <button class="hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+    <div class="mobile-menu" id="mobile-menu">
+      <a href="index.html#about">About</a>
+      <a href="index.html#pillars">What We Do</a>
+      <a href="index.html#network">The Network</a>
+      <a href="index.html#connect">Contact</a>
+      <a href="index.html#connect" class="btn btn-primary">Join Now</a>
+    </div>
+  </nav>
+
+  <!-- ═══ PAGE HEADER ═══ -->
+  <header class="page-header">
+    <div class="container">
+      <span class="eyebrow">Legal</span>
+      <h1>Cookie Policy</h1>
+      <p class="section-sub">Last updated: July 1, 2026</p>
+    </div>
+  </header>
+
+  <!-- ═══ COOKIE POLICY CONTENT ═══ -->
+  <section class="section legal">
+    <div class="container">
+      <div class="legal-content fade-in">
+        <p>
+          This Cookie Policy explains how The ILS Network ("we," "us," or "our") uses cookies and
+          similar technologies on theILSnetwork.com (the "Site").
+        </p>
+
+        <h2>1. What Are Cookies</h2>
+        <p>Cookies are small text files placed on your device by websites you visit. They're
+          commonly used to make sites work, remember preferences, or gather usage information.</p>
+
+        <h2>2. Cookies We Use</h2>
+        <p>The Site itself does not set any first-party cookies. We do not run analytics,
+          advertising, or tracking scripts.</p>
+
+        <h2>3. Third-Party Cookies</h2>
+        <p>Some third-party services embedded in the Site may set their own cookies or use similar
+          technologies under their own policies, independent of us:</p>
+        <ul>
+          <li><strong>Google Fonts</strong> — loads typefaces from Google's servers, which may
+            involve requests to Google's infrastructure. See
+            <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Google's Cookie Policy</a>.</li>
+          <li><strong>Formspree</strong> — processes contact form submissions and may use cookies
+            as part of that service. See
+            <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">Formspree's Privacy Policy</a>.</li>
+        </ul>
+
+        <h2>4. Managing Cookies</h2>
+        <p>Most browsers let you block or delete cookies through their settings. Since the Site
+          does not rely on cookies to function, blocking third-party cookies should not affect your
+          ability to browse the Site, though it may affect embedded third-party features.</p>
+
+        <h2>5. Changes to This Policy</h2>
+        <p>We may update this Cookie Policy from time to time. The "Last updated" date at the top
+          of this page reflects the most recent revision.</p>
+
+        <h2>6. Contact Us</h2>
+        <p>Questions about this Cookie Policy can be sent to
+          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FOOTER ═══ -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <p>Where vision meets community.</p>
+          <div class="social-links">
+            <a href="#" aria-label="LinkedIn" title="LinkedIn">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+            </a>
+            <a href="#" aria-label="X" title="X / Twitter">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="#" aria-label="Instagram" title="Instagram">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none"/></svg>
+            </a>
+            <a href="#" aria-label="YouTube" title="YouTube">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58A2.78 2.78 0 0 0 3.41 19.6C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z"/><polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" fill="white"/></svg>
+            </a>
+          </div>
+        </div>
+        <div class="footer-cols">
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="index.html#about">About</a></li>
+              <li><a href="index.html#pillars">What We Do</a></li>
+              <li><a href="index.html#network">The Network</a></li>
+              <li><a href="index.html#connect">Contact</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Community</h4>
+            <ul>
+              <li><a href="index.html#connect">Join the Network</a></li>
+              <li><a href="index.html#connect">Partner With Us</a></li>
+              <li><a href="index.html#connect">Media &amp; Press</a></li>
+              <li><a href="index.html#connect">Speaking Requests</a></li>
+              <li><a href="index.html#connect">Advertise</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="index.html#connect">Newsletter</a></li>
+              <li><a href="index.html#connect">Events</a></li>
+              <li><a href="index.html#connect">Podcast</a></li>
+              <li><a href="index.html#connect">Blog</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="privacy.html">Privacy Policy</a></li>
+              <li><a href="terms.html">Terms of Service</a></li>
+              <li><a href="cookies.html">Cookie Policy</a></li>
+              <li><a href="disclaimer.html">Disclaimer</a></li>
+              <li><a href="accessibility.html">Accessibility</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 The ILS Network. All rights reserved.</p>
+        <p>theILSnetwork.com</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Disclaimer for The ILS Network — the limits of the information and services provided on theILSnetwork.com.">
+  <meta property="og:title" content="Disclaimer — The ILS Network">
+  <meta property="og:description" content="The limits of the information and services provided on theILSnetwork.com.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://theILSnetwork.com/disclaimer.html">
+  <title>Disclaimer — The ILS Network</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- ═══ NAVIGATION ═══ -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <ul class="nav-links">
+        <li><a href="index.html#about">About</a></li>
+        <li><a href="index.html#pillars">What We Do</a></li>
+        <li><a href="index.html#network">The Network</a></li>
+        <li><a href="index.html#connect">Contact</a></li>
+      </ul>
+      <a href="index.html#connect" class="btn btn-primary nav-cta">Join Now</a>
+      <button class="hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+    <div class="mobile-menu" id="mobile-menu">
+      <a href="index.html#about">About</a>
+      <a href="index.html#pillars">What We Do</a>
+      <a href="index.html#network">The Network</a>
+      <a href="index.html#connect">Contact</a>
+      <a href="index.html#connect" class="btn btn-primary">Join Now</a>
+    </div>
+  </nav>
+
+  <!-- ═══ PAGE HEADER ═══ -->
+  <header class="page-header">
+    <div class="container">
+      <span class="eyebrow">Legal</span>
+      <h1>Disclaimer</h1>
+      <p class="section-sub">Last updated: July 1, 2026</p>
+    </div>
+  </header>
+
+  <!-- ═══ DISCLAIMER CONTENT ═══ -->
+  <section class="section legal">
+    <div class="container">
+      <div class="legal-content fade-in">
+        <p>
+          This Disclaimer applies to theILSnetwork.com (the "Site") and describes the limits of the
+          information and services provided by The ILS Network ("we," "us," or "our").
+        </p>
+
+        <h2>1. No Professional Advice</h2>
+        <p>Content on the Site — including descriptions of our pillars, community, and any material
+          we publish — is provided for general informational purposes only. It does not constitute
+          legal, financial, business, or professional advice, and should not be relied on as such.
+          Always seek independent advice before making decisions based on anything you read here.</p>
+
+        <h2>2. Membership Outcomes</h2>
+        <p>References to network members, industries represented, or possible outcomes of
+          participation are for illustrative purposes. We do not guarantee any specific result,
+          business outcome, or introduction from participating in The ILS Network.</p>
+
+        <h2>3. Third-Party Content and Links</h2>
+        <p>The Site may reference or link to third-party individuals, organizations, or services. We
+          do not control and are not responsible for the accuracy, content, or practices of any
+          third party, and inclusion does not imply our endorsement.</p>
+
+        <h2>4. Accuracy of Information</h2>
+        <p>We aim to keep information on the Site accurate and current but make no warranties, express
+          or implied, about its completeness, reliability, or accuracy. We may change or remove
+          content on the Site at any time without notice.</p>
+
+        <h2>5. Limitation of Liability</h2>
+        <p>To the fullest extent permitted by law, The ILS Network is not liable for any loss or
+          damage arising from reliance on information found on the Site or from your participation
+          in the network.</p>
+
+        <h2>6. Changes to This Disclaimer</h2>
+        <p>We may update this Disclaimer from time to time. The "Last updated" date at the top of
+          this page reflects the most recent revision.</p>
+
+        <h2>7. Contact Us</h2>
+        <p>Questions about this Disclaimer can be sent to
+          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FOOTER ═══ -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <p>Where vision meets community.</p>
+          <div class="social-links">
+            <a href="#" aria-label="LinkedIn" title="LinkedIn">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+            </a>
+            <a href="#" aria-label="X" title="X / Twitter">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="#" aria-label="Instagram" title="Instagram">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none"/></svg>
+            </a>
+            <a href="#" aria-label="YouTube" title="YouTube">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58A2.78 2.78 0 0 0 3.41 19.6C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z"/><polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" fill="white"/></svg>
+            </a>
+          </div>
+        </div>
+        <div class="footer-cols">
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="index.html#about">About</a></li>
+              <li><a href="index.html#pillars">What We Do</a></li>
+              <li><a href="index.html#network">The Network</a></li>
+              <li><a href="index.html#connect">Contact</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Community</h4>
+            <ul>
+              <li><a href="index.html#connect">Join the Network</a></li>
+              <li><a href="index.html#connect">Partner With Us</a></li>
+              <li><a href="index.html#connect">Media &amp; Press</a></li>
+              <li><a href="index.html#connect">Speaking Requests</a></li>
+              <li><a href="index.html#connect">Advertise</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="index.html#connect">Newsletter</a></li>
+              <li><a href="index.html#connect">Events</a></li>
+              <li><a href="index.html#connect">Podcast</a></li>
+              <li><a href="index.html#connect">Blog</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="privacy.html">Privacy Policy</a></li>
+              <li><a href="terms.html">Terms of Service</a></li>
+              <li><a href="cookies.html">Cookie Policy</a></li>
+              <li><a href="disclaimer.html">Disclaimer</a></li>
+              <li><a href="accessibility.html">Accessibility</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 The ILS Network. All rights reserved.</p>
+        <p>theILSnetwork.com</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -100,7 +100,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -100,7 +100,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="#" class="logo"><span>The</span> ILS<span>Network</span></a>
+      <a href="#" class="logo">ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="#about">About</a></li>
         <li><a href="#pillars">What We Do</a></li>
@@ -252,7 +252,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="#" class="logo"><span>The</span> ILS<span>Network</span></a>
+          <a href="#" class="logo">ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
           <div class="contact-items">
             <div class="contact-item">
               <span class="clabel">Email</span>
-              <a href="mailto:joshua@theilsnetwork.com">joshua@theilsnetwork.com</a>
+              <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>
             </div>
             <div class="contact-item">
               <span class="clabel">Website</span>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="#" class="logo">ILS<span>Network</span></a>
+      <a href="#" class="logo"><span>The</span> ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="#about">About</a></li>
         <li><a href="#pillars">What We Do</a></li>
@@ -252,7 +252,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="#" class="logo">ILS<span>Network</span></a>
+          <a href="#" class="logo"><span>The</span> ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
           <div class="footer-col">
             <h4>Legal</h4>
             <ul>
-              <li><a href="privacy_policy.html">Privacy Policy</a></li>
+              <li><a href="privacy.html">Privacy Policy</a></li>
               <li><a href="terms.html">Terms of Service</a></li>
               <li><a href="cookies.html">Cookie Policy</a></li>
               <li><a href="disclaimer.html">Disclaimer</a></li>

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
           <div class="footer-col">
             <h4>Legal</h4>
             <ul>
-              <li><a href="privacy.html">Privacy Policy</a></li>
+              <li><a href="privacy_policy.html">Privacy Policy</a></li>
               <li><a href="terms.html">Terms of Service</a></li>
               <li><a href="cookies.html">Cookie Policy</a></li>
               <li><a href="disclaimer.html">Disclaimer</a></li>

--- a/privacy.html
+++ b/privacy.html
@@ -106,7 +106,7 @@
 
         <h2>6. Your Rights and Choices</h2>
         <p>You may ask us to access, correct, or delete the personal information you've submitted
-          to us by emailing <a href="mailto:joshua@theilsnetwork.com">joshua@theilsnetwork.com</a>.
+          to us by emailing <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.
           We will respond to reasonable requests within a reasonable timeframe.</p>
 
         <h2>7. Children's Privacy</h2>
@@ -122,7 +122,7 @@
 
         <h2>9. Contact Us</h2>
         <p>Questions about this Privacy Policy can be sent to
-          <a href="mailto:joshua@theilsnetwork.com">joshua@theilsnetwork.com</a>.</p>
+          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
       </div>
     </div>
   </section>

--- a/privacy.html
+++ b/privacy.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -132,7 +132,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/privacy.html
+++ b/privacy.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -132,7 +132,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/privacy.html
+++ b/privacy.html
@@ -7,7 +7,7 @@
   <meta property="og:title" content="Privacy Policy — The ILS Network">
   <meta property="og:description" content="How theILSnetwork.com collects, uses, and protects your information.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://theILSnetwork.com/privacy_policy">
+  <meta property="og:url" content="https://theILSnetwork.com/privacy.html">
   <title>Privacy Policy — The ILS Network</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -181,7 +181,7 @@
           <div class="footer-col">
             <h4>Legal</h4>
             <ul>
-              <li><a href="privacy_policy.html">Privacy Policy</a></li>
+              <li><a href="privacy.html">Privacy Policy</a></li>
               <li><a href="terms.html">Terms of Service</a></li>
               <li><a href="cookies.html">Cookie Policy</a></li>
               <li><a href="disclaimer.html">Disclaimer</a></li>

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Privacy Policy for The ILS Network — how theILSnetwork.com collects, uses, and protects your information.">
+  <meta property="og:title" content="Privacy Policy — The ILS Network">
+  <meta property="og:description" content="How theILSnetwork.com collects, uses, and protects your information.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://theILSnetwork.com/privacy_policy">
+  <title>Privacy Policy — The ILS Network</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- ═══ NAVIGATION ═══ -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <ul class="nav-links">
+        <li><a href="index.html#about">About</a></li>
+        <li><a href="index.html#pillars">What We Do</a></li>
+        <li><a href="index.html#network">The Network</a></li>
+        <li><a href="index.html#connect">Contact</a></li>
+      </ul>
+      <a href="index.html#connect" class="btn btn-primary nav-cta">Join Now</a>
+      <button class="hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+    <div class="mobile-menu" id="mobile-menu">
+      <a href="index.html#about">About</a>
+      <a href="index.html#pillars">What We Do</a>
+      <a href="index.html#network">The Network</a>
+      <a href="index.html#connect">Contact</a>
+      <a href="index.html#connect" class="btn btn-primary">Join Now</a>
+    </div>
+  </nav>
+
+  <!-- ═══ PAGE HEADER ═══ -->
+  <header class="page-header">
+    <div class="container">
+      <span class="eyebrow">Legal</span>
+      <h1>Privacy Policy</h1>
+      <p class="section-sub">Last updated: July 1, 2026</p>
+    </div>
+  </header>
+
+  <!-- ═══ POLICY CONTENT ═══ -->
+  <section class="section legal">
+    <div class="container">
+      <div class="legal-content fade-in">
+        <p>
+          The ILS Network ("we," "us," or "our") operates theILSnetwork.com (the "Site"). This
+          Privacy Policy explains what information we collect when you visit the Site, how we use
+          it, and the choices you have. By using the Site, you agree to the practices described here.
+        </p>
+
+        <h2>1. Information We Collect</h2>
+        <p><strong>Contact form submissions.</strong> When you fill out the form in the Connect
+          section of the Site, we collect the information you provide: your name, email address,
+          topic of interest, and message. This information is submitted directly to Formspree, our
+          form-processing provider, and forwarded to us so we can respond to you.</p>
+        <p><strong>Automatically collected information.</strong> The Site is hosted on GitHub
+          Pages. As with any web request, GitHub's servers may log standard technical information
+          such as your IP address, browser type, and request timestamps. We do not have direct
+          access to these logs; they are governed by
+          <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank" rel="noopener">GitHub's own privacy statement</a>.</p>
+        <p>We do not use analytics scripts, advertising trackers, or first-party cookies of our own
+          on this Site.</p>
+
+        <h2>2. How We Use Your Information</h2>
+        <p>We use the information you submit through the contact form to:</p>
+        <ul>
+          <li>Respond to your inquiry, whether about joining the network, a partnership, media and
+            press, or a speaking request;</li>
+          <li>Communicate with you about the ILS Network community, if you've asked to join; and</li>
+          <li>Maintain a record of correspondence so we can follow up appropriately.</li>
+        </ul>
+        <p>We do not sell your personal information, and we do not share it with third parties for
+          their own marketing purposes.</p>
+
+        <h2>3. Third-Party Services</h2>
+        <p>The Site relies on a small number of third-party services to function:</p>
+        <ul>
+          <li><strong>Formspree</strong> — processes and delivers contact form submissions. See
+            <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">Formspree's Privacy Policy</a>.</li>
+          <li><strong>Google Fonts</strong> — loads the Inter and Space Grotesk typefaces from
+            Google's servers, which may receive your IP address as part of that request. See
+            <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google's Privacy Policy</a>.</li>
+          <li><strong>GitHub Pages</strong> — hosts and serves the Site's files.</li>
+        </ul>
+
+        <h2>4. Cookies and Tracking</h2>
+        <p>We do not set our own cookies or use tracking pixels. Third-party services referenced
+          above (such as Google Fonts) may set cookies or process requests under their own
+          policies, independent of this Site.</p>
+
+        <h2>5. Data Retention</h2>
+        <p>We retain contact form submissions for as long as needed to respond to your inquiry and
+          maintain reasonable business records, after which we delete them. You can request earlier
+          deletion at any time — see Section 6 below.</p>
+
+        <h2>6. Your Rights and Choices</h2>
+        <p>You may ask us to access, correct, or delete the personal information you've submitted
+          to us by emailing <a href="mailto:joshua@theilsnetwork.com">joshua@theilsnetwork.com</a>.
+          We will respond to reasonable requests within a reasonable timeframe.</p>
+
+        <h2>7. Children's Privacy</h2>
+        <p>The Site is not directed at children under 13, and we do not knowingly collect personal
+          information from children. If you believe a child has provided us information, contact us
+          and we will remove it.</p>
+
+        <h2>8. Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time to reflect changes to the Site or
+          our practices. The "Last updated" date at the top of this page reflects the most recent
+          revision. Continued use of the Site after changes are posted constitutes acceptance of the
+          updated policy.</p>
+
+        <h2>9. Contact Us</h2>
+        <p>Questions about this Privacy Policy can be sent to
+          <a href="mailto:joshua@theilsnetwork.com">joshua@theilsnetwork.com</a>.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FOOTER ═══ -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <p>Where vision meets community.</p>
+          <div class="social-links">
+            <a href="#" aria-label="LinkedIn" title="LinkedIn">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+            </a>
+            <a href="#" aria-label="X" title="X / Twitter">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="#" aria-label="Instagram" title="Instagram">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none"/></svg>
+            </a>
+            <a href="#" aria-label="YouTube" title="YouTube">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58A2.78 2.78 0 0 0 3.41 19.6C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z"/><polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" fill="white"/></svg>
+            </a>
+          </div>
+        </div>
+        <div class="footer-cols">
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="index.html#about">About</a></li>
+              <li><a href="index.html#pillars">What We Do</a></li>
+              <li><a href="index.html#network">The Network</a></li>
+              <li><a href="index.html#connect">Contact</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Community</h4>
+            <ul>
+              <li><a href="index.html#connect">Join the Network</a></li>
+              <li><a href="index.html#connect">Partner With Us</a></li>
+              <li><a href="index.html#connect">Media &amp; Press</a></li>
+              <li><a href="index.html#connect">Speaking Requests</a></li>
+              <li><a href="index.html#connect">Advertise</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="index.html#connect">Newsletter</a></li>
+              <li><a href="index.html#connect">Events</a></li>
+              <li><a href="index.html#connect">Podcast</a></li>
+              <li><a href="index.html#connect">Blog</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="privacy_policy.html">Privacy Policy</a></li>
+              <li><a href="terms.html">Terms of Service</a></li>
+              <li><a href="cookies.html">Cookie Policy</a></li>
+              <li><a href="disclaimer.html">Disclaimer</a></li>
+              <li><a href="accessibility.html">Accessibility</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 The ILS Network. All rights reserved.</p>
+        <p>theILSnetwork.com</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -605,6 +605,13 @@ a:hover { color: var(--accent); }
 }
 .legal-content li { margin-bottom: 8px; }
 .legal-content strong { color: var(--text); }
+.legal-content code {
+  font-size: 0.9em;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+}
 .legal-content a {
   color: var(--accent);
   text-decoration: underline;

--- a/style.css
+++ b/style.css
@@ -579,6 +579,38 @@ a:hover { color: var(--accent); }
 }
 .footer-bottom p { font-size: 0.875rem; }
 
+/* ─── LEGAL PAGES ─── */
+.page-header {
+  padding: calc(var(--nav-h) + 64px) 0 56px;
+  text-align: center;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+}
+.page-header h1 { margin: 10px 0 14px; }
+.page-header .section-sub { max-width: 620px; margin: 0 auto; color: var(--muted); }
+.legal-content { max-width: 720px; margin: 0 auto; }
+.legal-content h2 {
+  font-size: 1.375rem;
+  margin: 40px 0 14px;
+}
+.legal-content h2:first-of-type { margin-top: 0; }
+.legal-content p  { margin-bottom: 16px; }
+.legal-content ul {
+  list-style: disc;
+  padding-left: 22px;
+  margin: -4px 0 16px;
+  color: var(--muted);
+  font-size: 1.0625rem;
+  line-height: 1.75;
+}
+.legal-content li { margin-bottom: 8px; }
+.legal-content strong { color: var(--text); }
+.legal-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 /* ─── SCROLL ANIMATIONS ─── */
 .fade-in {
   opacity: 0;

--- a/terms.html
+++ b/terms.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -124,7 +124,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Terms of Service for The ILS Network — the rules for using theILSnetwork.com and participating in the network.">
+  <meta property="og:title" content="Terms of Service — The ILS Network">
+  <meta property="og:description" content="The rules for using theILSnetwork.com and participating in the network.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://theILSnetwork.com/terms.html">
+  <title>Terms of Service — The ILS Network</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- ═══ NAVIGATION ═══ -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
+      <ul class="nav-links">
+        <li><a href="index.html#about">About</a></li>
+        <li><a href="index.html#pillars">What We Do</a></li>
+        <li><a href="index.html#network">The Network</a></li>
+        <li><a href="index.html#connect">Contact</a></li>
+      </ul>
+      <a href="index.html#connect" class="btn btn-primary nav-cta">Join Now</a>
+      <button class="hamburger" id="hamburger" aria-label="Toggle menu" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+    <div class="mobile-menu" id="mobile-menu">
+      <a href="index.html#about">About</a>
+      <a href="index.html#pillars">What We Do</a>
+      <a href="index.html#network">The Network</a>
+      <a href="index.html#connect">Contact</a>
+      <a href="index.html#connect" class="btn btn-primary">Join Now</a>
+    </div>
+  </nav>
+
+  <!-- ═══ PAGE HEADER ═══ -->
+  <header class="page-header">
+    <div class="container">
+      <span class="eyebrow">Legal</span>
+      <h1>Terms of Service</h1>
+      <p class="section-sub">Last updated: July 1, 2026</p>
+    </div>
+  </header>
+
+  <!-- ═══ TERMS CONTENT ═══ -->
+  <section class="section legal">
+    <div class="container">
+      <div class="legal-content fade-in">
+        <p>
+          These Terms of Service ("Terms") govern your access to and use of theILSnetwork.com (the
+          "Site") and your participation in The ILS Network ("we," "us," or "our"). By using the
+          Site or joining the network, you agree to these Terms. If you do not agree, please do not
+          use the Site.
+        </p>
+
+        <h2>1. Who We Are</h2>
+        <p>The ILS Network is a community for entrepreneurs, executives, creators, and other
+          professionals who connect, create, and lead together, spanning industries, backgrounds,
+          and borders.</p>
+
+        <h2>2. Eligibility</h2>
+        <p>You must be at least 18 years old to submit the contact form, request to join the
+          network, or otherwise engage with the Site on your own behalf.</p>
+
+        <h2>3. Using the Site</h2>
+        <p>You agree to use the Site only for lawful purposes. You agree not to:</p>
+        <ul>
+          <li>Submit false, misleading, or fraudulent information through the contact form;</li>
+          <li>Attempt to disrupt, overload, or gain unauthorized access to the Site or its
+            underlying infrastructure;</li>
+          <li>Use the Site to harass, defraud, or harm another person or organization; or</li>
+          <li>Scrape, copy, or republish substantial portions of the Site's content without our
+            permission.</li>
+        </ul>
+
+        <h2>4. Joining the Network</h2>
+        <p>Submitting the contact form or expressing interest in joining the network does not
+          guarantee membership. We may accept, decline, or remove members at our discretion,
+          including for conduct that is inconsistent with the spirit of the community.</p>
+
+        <h2>5. Intellectual Property</h2>
+        <p>The Site's content — including its design, text, graphics, and logos — belongs to The
+          ILS Network or its licensors and is protected by applicable intellectual property laws.
+          You may not use our name, branding, or content to imply endorsement without our written
+          permission.</p>
+
+        <h2>6. Third-Party Services and Links</h2>
+        <p>The Site uses third-party services, including Formspree for contact form processing and
+          Google Fonts for typography, and may link to third-party sites such as social media
+          profiles. We are not responsible for the content, policies, or practices of any
+          third-party service or site.</p>
+
+        <h2>7. Disclaimer of Warranties</h2>
+        <p>The Site and all content on it are provided "as is" and "as available," without
+          warranties of any kind, whether express or implied. We do not guarantee that the Site
+          will be uninterrupted, secure, or error-free.</p>
+
+        <h2>8. Limitation of Liability</h2>
+        <p>To the fullest extent permitted by law, The ILS Network will not be liable for any
+          indirect, incidental, or consequential damages arising from your use of, or inability to
+          use, the Site or your participation in the network.</p>
+
+        <h2>9. Changes to These Terms</h2>
+        <p>We may update these Terms from time to time. The "Last updated" date at the top of this
+          page reflects the most recent revision. Continued use of the Site after changes are
+          posted constitutes acceptance of the updated Terms.</p>
+
+        <h2>10. Contact Us</h2>
+        <p>Questions about these Terms can be sent to
+          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FOOTER ═══ -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
+          <p>Where vision meets community.</p>
+          <div class="social-links">
+            <a href="#" aria-label="LinkedIn" title="LinkedIn">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+            </a>
+            <a href="#" aria-label="X" title="X / Twitter">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="#" aria-label="Instagram" title="Instagram">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none"/></svg>
+            </a>
+            <a href="#" aria-label="YouTube" title="YouTube">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58A2.78 2.78 0 0 0 3.41 19.6C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z"/><polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" fill="white"/></svg>
+            </a>
+          </div>
+        </div>
+        <div class="footer-cols">
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="index.html#about">About</a></li>
+              <li><a href="index.html#pillars">What We Do</a></li>
+              <li><a href="index.html#network">The Network</a></li>
+              <li><a href="index.html#connect">Contact</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Community</h4>
+            <ul>
+              <li><a href="index.html#connect">Join the Network</a></li>
+              <li><a href="index.html#connect">Partner With Us</a></li>
+              <li><a href="index.html#connect">Media &amp; Press</a></li>
+              <li><a href="index.html#connect">Speaking Requests</a></li>
+              <li><a href="index.html#connect">Advertise</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="index.html#connect">Newsletter</a></li>
+              <li><a href="index.html#connect">Events</a></li>
+              <li><a href="index.html#connect">Podcast</a></li>
+              <li><a href="index.html#connect">Blog</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="privacy.html">Privacy Policy</a></li>
+              <li><a href="terms.html">Terms of Service</a></li>
+              <li><a href="cookies.html">Cookie Policy</a></li>
+              <li><a href="disclaimer.html">Disclaimer</a></li>
+              <li><a href="accessibility.html">Accessibility</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 The ILS Network. All rights reserved.</p>
+        <p>theILSnetwork.com</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -19,7 +19,7 @@
   <!-- ═══ NAVIGATION ═══ -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
-      <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+      <a href="index.html" class="logo">ILS<span>Network</span></a>
       <ul class="nav-links">
         <li><a href="index.html#about">About</a></li>
         <li><a href="index.html#pillars">What We Do</a></li>
@@ -124,7 +124,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="index.html" class="logo"><span>The</span> ILS<span>Network</span></a>
+          <a href="index.html" class="logo">ILS<span>Network</span></a>
           <p>Where vision meets community.</p>
           <div class="social-links">
             <a href="#" aria-label="LinkedIn" title="LinkedIn">


### PR DESCRIPTION
## Summary
- Adds `privacy.html`, `terms.html`, `cookies.html`, `disclaimer.html`, and `accessibility.html` — fixes the previously dead footer links to these pages.
- Each page reuses the homepage's nav, footer, fonts, and theme variables (new `.page-header` / `.legal-content` CSS added to `style.css`, scoped to these pages only).
- Updates the public contact address from `joshua@theilsnetwork.com` to `support@theilsnetwork.com` in `index.html` and the new pages.

## Test plan
- Served the site locally (`python3 -m http.server`) and screenshot-verified each new page renders correctly with the existing dark theme, nav, and footer.
- Confirmed all footer legal links resolve to real pages (no more 404s).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BftjSvhM7KKGEXMXuMMoa1)_