### PR TITLE
Connect contact form to live Formspree endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
             </div>
           </div>
         </div>
-        <form class="contact-form fade-in" id="contact-form" action="https://formspree.io/f/YOUR_FORM_ID" method="POST">
+        <form class="contact-form fade-in" id="contact-form" action="https://formspree.io/f/xvzjwnwj" method="POST">
           <div class="form-row">
             <div class="form-group">
               <label for="fname">Name</label>


### PR DESCRIPTION
## Summary
- Points the `#connect` contact form's `action` at the real Formspree endpoint (`https://formspree.io/f/xvzjwnwj`) instead of the `YOUR_FORM_ID` placeholder.
- No JS changes needed: `script.js` already posts `FormData` with `Accept: application/json` via `fetch` and shows custom success/error messaging matching the site's theme — functionally equivalent to Formspree's "Vanilla JS (Ajax)" integration guide, just hand-rolled to avoid adding an external dependency (this site intentionally has none, per `CLAUDE.md`). Adopting the official `@formspree/ajax` library would mean pulling in a CDN script and restructuring the form around `data-fs-*` attributes just to replace UI that already works.
- The placeholder guard in `script.js` (which shows a "form not yet connected" message) simply stops firing now that a real ID is set.

## Test plan
- Verified the form's `action` attribute now points at the real endpoint and no longer contains `YOUR_FORM_ID`.
- Did not submit a live test message from this session — see notes for the user on activating the form.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BftjSvhM7KKGEXMXuMMoa1)_