### PR TITLE
Add content pages for Join, Partner, Media, Speaking, and Advertise footer links

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -127,11 +127,11 @@
           <div class="footer-col">
             <h4>Community</h4>
             <ul>
-              <li><a href="index.html#connect">Join the Network</a></li>
-              <li><a href="index.html#connect">Partner With Us</a></li>
-              <li><a href="index.html#connect">Media &amp; Press</a></li>
-              <li><a href="index.html#connect">Speaking Requests</a></li>
-              <li><a href="index.html#connect">Advertise</a></li>
+              <li><a href="join.html">Join the Network</a></li>
+              <li><a href="partner.html">Partner With Us</a></li>
+              <li><a href="media.html">Media &amp; Press</a></li>
+              <li><a href="speaking.html">Speaking Requests</a></li>
+              <li><a href="advertise.html">Advertise</a></li>
             </ul>
           </div>
           <div class="footer-col">

--- a/advertise.html
+++ b/advertise.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Cookie Policy for The ILS Network — what cookies and similar technologies are used on theILSnetwork.com.">
-  <meta property="og:title" content="Cookie Policy — The ILS Network">
-  <meta property="og:description" content="What cookies and similar technologies are used on theILSnetwork.com.">
+  <meta name="description" content="Advertising and sponsorship opportunities with The ILS Network.">
+  <meta property="og:title" content="Advertise — The ILS Network">
+  <meta property="og:description" content="Advertising and sponsorship opportunities with The ILS Network.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://theILSnetwork.com/cookies.html">
-  <title>Cookie Policy — The ILS Network</title>
+  <meta property="og:url" content="https://theILSnetwork.com/advertise.html">
+  <title>Advertise — The ILS Network</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -43,53 +43,32 @@
   <!-- ═══ PAGE HEADER ═══ -->
   <header class="page-header">
     <div class="container">
-      <span class="eyebrow">Legal</span>
-      <h1>Cookie Policy</h1>
-      <p class="section-sub">Last updated: July 1, 2026</p>
+      <span class="eyebrow">Advertising</span>
+      <h1>Advertise With Us</h1>
+      <p class="section-sub">Reach a curated community of entrepreneurs, executives, and creators.</p>
     </div>
   </header>
 
-  <!-- ═══ COOKIE POLICY CONTENT ═══ -->
+  <!-- ═══ ADVERTISE CONTENT ═══ -->
   <section class="section legal">
     <div class="container">
       <div class="legal-content fade-in">
         <p>
-          This Cookie Policy explains how The ILS Network ("we," "us," or "our") uses cookies and
-          similar technologies on theILSnetwork.com (the "Site").
+          The ILS Network is building out dedicated advertising channels — including our
+          newsletter, events, and social presence — to help partners reach our community. These
+          channels are still in development.
         </p>
 
-        <h2>1. What Are Cookies</h2>
-        <p>Cookies are small text files placed on your device by websites you visit. They're
-          commonly used to make sites work, remember preferences, or gather usage information.</p>
+        <h2>Interested Early?</h2>
+        <p>
+          Reach out to discuss upcoming advertising and sponsorship opportunities. We'll follow up
+          as channels come online and keep you in mind as availability opens up.
+        </p>
 
-        <h2>2. Cookies We Use</h2>
-        <p>The Site itself does not set any first-party cookies. We do not run analytics,
-          advertising, or tracking scripts.</p>
-
-        <h2>3. Third-Party Cookies</h2>
-        <p>Some third-party services embedded in the Site may set their own cookies or use similar
-          technologies under their own policies, independent of us:</p>
-        <ul>
-          <li><strong>Google Fonts</strong> — loads typefaces from Google's servers, which may
-            involve requests to Google's infrastructure. See
-            <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Google's Cookie Policy</a>.</li>
-          <li><strong>Formspree</strong> — processes contact form submissions and may use cookies
-            as part of that service. See
-            <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">Formspree's Privacy Policy</a>.</li>
-        </ul>
-
-        <h2>4. Managing Cookies</h2>
-        <p>Most browsers let you block or delete cookies through their settings. Since the Site
-          does not rely on cookies to function, blocking third-party cookies should not affect your
-          ability to browse the Site, though it may affect embedded third-party features.</p>
-
-        <h2>5. Changes to This Policy</h2>
-        <p>We may update this Cookie Policy from time to time. The "Last updated" date at the top
-          of this page reflects the most recent revision.</p>
-
-        <h2>6. Contact Us</h2>
-        <p>Questions about this Cookie Policy can be sent to
-          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+        <a href="index.html#connect" class="btn btn-primary" style="margin-top:8px;">Get in Touch</a>
+        <p style="margin-top:16px; font-size:0.9375rem;">
+          On the contact form, select <strong>"Advertising Inquiry"</strong> from the dropdown.
+        </p>
       </div>
     </div>
   </section>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -130,11 +130,11 @@
           <div class="footer-col">
             <h4>Community</h4>
             <ul>
-              <li><a href="index.html#connect">Join the Network</a></li>
-              <li><a href="index.html#connect">Partner With Us</a></li>
-              <li><a href="index.html#connect">Media &amp; Press</a></li>
-              <li><a href="index.html#connect">Speaking Requests</a></li>
-              <li><a href="index.html#connect">Advertise</a></li>
+              <li><a href="join.html">Join the Network</a></li>
+              <li><a href="partner.html">Partner With Us</a></li>
+              <li><a href="media.html">Media &amp; Press</a></li>
+              <li><a href="speaking.html">Speaking Requests</a></li>
+              <li><a href="advertise.html">Advertise</a></li>
             </ul>
           </div>
           <div class="footer-col">

--- a/index.html
+++ b/index.html
@@ -233,6 +233,7 @@
               <option value="partner">Partnership Inquiry</option>
               <option value="media">Media &amp; Press</option>
               <option value="speaking">Speaking Request</option>
+              <option value="advertise">Advertising Inquiry</option>
               <option value="other">General Inquiry</option>
             </select>
           </div>
@@ -282,11 +283,11 @@
           <div class="footer-col">
             <h4>Community</h4>
             <ul>
-              <li><a href="#connect">Join the Network</a></li>
-              <li><a href="#connect">Partner With Us</a></li>
-              <li><a href="#connect">Media &amp; Press</a></li>
-              <li><a href="#connect">Speaking Requests</a></li>
-              <li><a href="#connect">Advertise</a></li>
+              <li><a href="join.html">Join the Network</a></li>
+              <li><a href="partner.html">Partner With Us</a></li>
+              <li><a href="media.html">Media &amp; Press</a></li>
+              <li><a href="speaking.html">Speaking Requests</a></li>
+              <li><a href="advertise.html">Advertise</a></li>
             </ul>
           </div>
           <div class="footer-col">

--- a/join.html
+++ b/join.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Cookie Policy for The ILS Network — what cookies and similar technologies are used on theILSnetwork.com.">
-  <meta property="og:title" content="Cookie Policy — The ILS Network">
-  <meta property="og:description" content="What cookies and similar technologies are used on theILSnetwork.com.">
+  <meta name="description" content="Join The ILS Network — a curated community for entrepreneurs, executives, creators, and changemakers.">
+  <meta property="og:title" content="Join the Network — The ILS Network">
+  <meta property="og:description" content="A curated community for entrepreneurs, executives, creators, and changemakers.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://theILSnetwork.com/cookies.html">
-  <title>Cookie Policy — The ILS Network</title>
+  <meta property="og:url" content="https://theILSnetwork.com/join.html">
+  <title>Join the Network — The ILS Network</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -43,53 +43,45 @@
   <!-- ═══ PAGE HEADER ═══ -->
   <header class="page-header">
     <div class="container">
-      <span class="eyebrow">Legal</span>
-      <h1>Cookie Policy</h1>
-      <p class="section-sub">Last updated: July 1, 2026</p>
+      <span class="eyebrow">Community</span>
+      <h1>Join The ILS Network</h1>
+      <p class="section-sub">Where leaders connect, ideas take shape, and communities thrive.</p>
     </div>
   </header>
 
-  <!-- ═══ COOKIE POLICY CONTENT ═══ -->
+  <!-- ═══ JOIN CONTENT ═══ -->
   <section class="section legal">
     <div class="container">
       <div class="legal-content fade-in">
         <p>
-          This Cookie Policy explains how The ILS Network ("we," "us," or "our") uses cookies and
-          similar technologies on theILSnetwork.com (the "Site").
+          The ILS Network is a curated community for entrepreneurs, executives, media
+          professionals, tech founders, creators, and changemakers who'd rather build alongside
+          others than build alone. Membership connects you with people across industries,
+          backgrounds, and borders who share a drive to create something meaningful.
         </p>
 
-        <h2>1. What Are Cookies</h2>
-        <p>Cookies are small text files placed on your device by websites you visit. They're
-          commonly used to make sites work, remember preferences, or gather usage information.</p>
-
-        <h2>2. Cookies We Use</h2>
-        <p>The Site itself does not set any first-party cookies. We do not run analytics,
-          advertising, or tracking scripts.</p>
-
-        <h2>3. Third-Party Cookies</h2>
-        <p>Some third-party services embedded in the Site may set their own cookies or use similar
-          technologies under their own policies, independent of us:</p>
+        <h2>What Members Get</h2>
         <ul>
-          <li><strong>Google Fonts</strong> — loads typefaces from Google's servers, which may
-            involve requests to Google's infrastructure. See
-            <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Google's Cookie Policy</a>.</li>
-          <li><strong>Formspree</strong> — processes contact form submissions and may use cookies
-            as part of that service. See
-            <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">Formspree's Privacy Policy</a>.</li>
+          <li><strong>Connect</strong> — introductions to partners, collaborators, and mentors
+            already inside the network;</li>
+          <li><strong>Create</strong> — a platform and support for your ideas, content, and
+            projects; and</li>
+          <li><strong>Lead</strong> — masterminds, workshops, and real-world collaboration with
+            emerging and established leaders.</li>
         </ul>
 
-        <h2>4. Managing Cookies</h2>
-        <p>Most browsers let you block or delete cookies through their settings. Since the Site
-          does not rely on cookies to function, blocking third-party cookies should not affect your
-          ability to browse the Site, though it may affect embedded third-party features.</p>
+        <h2>How Membership Works</h2>
+        <p>
+          We're still finalizing the shape of membership — including whether it will be free,
+          application-based, or invite-only. Request to join today and our team will follow up
+          directly with current details and next steps.
+        </p>
 
-        <h2>5. Changes to This Policy</h2>
-        <p>We may update this Cookie Policy from time to time. The "Last updated" date at the top
-          of this page reflects the most recent revision.</p>
-
-        <h2>6. Contact Us</h2>
-        <p>Questions about this Cookie Policy can be sent to
-          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+        <a href="index.html#connect" class="btn btn-primary" style="margin-top:8px;">Request to Join</a>
+        <p style="margin-top:16px; font-size:0.9375rem;">
+          On the contact form, select <strong>"Joining the Network"</strong> from the dropdown so
+          your request reaches the right person.
+        </p>
       </div>
     </div>
   </section>

--- a/join.html
+++ b/join.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Join The ILS Network — a curated community for entrepreneurs, executives, creators, and changemakers.">
+  <meta name="description" content="The ILS Network isn't open enrollment. It's a curated group of entrepreneurs, executives, media professionals, and builders who back each other.">
   <meta property="og:title" content="Join the Network — The ILS Network">
-  <meta property="og:description" content="A curated community for entrepreneurs, executives, creators, and changemakers.">
+  <meta property="og:description" content="Not open enrollment. A curated group of builders who back each other, in the room and outside it.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://theILSnetwork.com/join.html">
   <title>Join the Network — The ILS Network</title>
@@ -43,9 +43,9 @@
   <!-- ═══ PAGE HEADER ═══ -->
   <header class="page-header">
     <div class="container">
-      <span class="eyebrow">Community</span>
+      <span class="eyebrow">Membership</span>
       <h1>Join The ILS Network</h1>
-      <p class="section-sub">Where leaders connect, ideas take shape, and communities thrive.</p>
+      <p class="section-sub">This isn't open enrollment.</p>
     </div>
   </header>
 
@@ -54,30 +54,33 @@
     <div class="container">
       <div class="legal-content fade-in">
         <p>
-          The ILS Network is a curated community for entrepreneurs, executives, media
-          professionals, tech founders, creators, and changemakers who'd rather build alongside
-          others than build alone. Membership connects you with people across industries,
-          backgrounds, and borders who share a drive to create something meaningful.
+          Integrated Life Styles — The ILS Network — isn't open enrollment. It's a curated group
+          of entrepreneurs, executives, media professionals, and builders who back each other, in
+          the room and outside it.
+        </p>
+        <p>
+          If you're actively building or leading something and want the right people around you
+          while you do it, tell us about it.
         </p>
 
-        <h2>What Members Get</h2>
+        <h2>What That Looks Like</h2>
         <ul>
           <li><strong>Connect</strong> — introductions to partners, collaborators, and mentors
             already inside the network;</li>
           <li><strong>Create</strong> — a platform and support for your ideas, content, and
             projects; and</li>
           <li><strong>Lead</strong> — masterminds, workshops, and real-world collaboration with
-            emerging and established leaders.</li>
+            people building at your level.</li>
         </ul>
 
-        <h2>How Membership Works</h2>
+        <h2>How It Works</h2>
         <p>
-          We're still finalizing the shape of membership — including whether it will be free,
-          application-based, or invite-only. Request to join today and our team will follow up
-          directly with current details and next steps.
+          This isn't a form that adds you to a list. Tell us what you're building or leading and
+          what you're looking for. We review every request personally — no open enrollment, no
+          automated approval. If it's a fit, we'll follow up directly with next steps.
         </p>
 
-        <a href="index.html#connect" class="btn btn-primary" style="margin-top:8px;">Request to Join</a>
+        <a href="index.html#connect" class="btn btn-primary" style="margin-top:8px;">Tell Us What You're Building</a>
         <p style="margin-top:16px; font-size:0.9375rem;">
           On the contact form, select <strong>"Joining the Network"</strong> from the dropdown so
           your request reaches the right person.

--- a/media.html
+++ b/media.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Cookie Policy for The ILS Network — what cookies and similar technologies are used on theILSnetwork.com.">
-  <meta property="og:title" content="Cookie Policy — The ILS Network">
-  <meta property="og:description" content="What cookies and similar technologies are used on theILSnetwork.com.">
+  <meta name="description" content="Media and press inquiries for The ILS Network.">
+  <meta property="og:title" content="Media & Press — The ILS Network">
+  <meta property="og:description" content="Media and press inquiries for The ILS Network.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://theILSnetwork.com/cookies.html">
-  <title>Cookie Policy — The ILS Network</title>
+  <meta property="og:url" content="https://theILSnetwork.com/media.html">
+  <title>Media &amp; Press — The ILS Network</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -43,53 +43,39 @@
   <!-- ═══ PAGE HEADER ═══ -->
   <header class="page-header">
     <div class="container">
-      <span class="eyebrow">Legal</span>
-      <h1>Cookie Policy</h1>
-      <p class="section-sub">Last updated: July 1, 2026</p>
+      <span class="eyebrow">Press</span>
+      <h1>Media &amp; Press</h1>
+      <p class="section-sub">Interviews, commentary, and coverage of The ILS Network.</p>
     </div>
   </header>
 
-  <!-- ═══ COOKIE POLICY CONTENT ═══ -->
+  <!-- ═══ MEDIA CONTENT ═══ -->
   <section class="section legal">
     <div class="container">
       <div class="legal-content fade-in">
         <p>
-          This Cookie Policy explains how The ILS Network ("we," "us," or "our") uses cookies and
-          similar technologies on theILSnetwork.com (the "Site").
+          Journalists, podcasters, and content creators covering entrepreneurship, community
+          building, media, or leadership are welcome to reach out for interviews, commentary, or
+          background on The ILS Network.
         </p>
 
-        <h2>1. What Are Cookies</h2>
-        <p>Cookies are small text files placed on your device by websites you visit. They're
-          commonly used to make sites work, remember preferences, or gather usage information.</p>
-
-        <h2>2. Cookies We Use</h2>
-        <p>The Site itself does not set any first-party cookies. We do not run analytics,
-          advertising, or tracking scripts.</p>
-
-        <h2>3. Third-Party Cookies</h2>
-        <p>Some third-party services embedded in the Site may set their own cookies or use similar
-          technologies under their own policies, independent of us:</p>
+        <h2>What We Can Help With</h2>
         <ul>
-          <li><strong>Google Fonts</strong> — loads typefaces from Google's servers, which may
-            involve requests to Google's infrastructure. See
-            <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Google's Cookie Policy</a>.</li>
-          <li><strong>Formspree</strong> — processes contact form submissions and may use cookies
-            as part of that service. See
-            <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">Formspree's Privacy Policy</a>.</li>
+          <li>Interviews with The ILS Network's leadership;</li>
+          <li>Commentary on trends in community building, media, and entrepreneurship; and</li>
+          <li>Background information for stories that mention the network.</li>
         </ul>
 
-        <h2>4. Managing Cookies</h2>
-        <p>Most browsers let you block or delete cookies through their settings. Since the Site
-          does not rely on cookies to function, blocking third-party cookies should not affect your
-          ability to browse the Site, though it may affect embedded third-party features.</p>
+        <h2>Press Kit</h2>
+        <p>
+          A downloadable press kit (logos, boilerplate copy, and headshots) is in progress. In the
+          meantime, reach out directly and we'll send what you need.
+        </p>
 
-        <h2>5. Changes to This Policy</h2>
-        <p>We may update this Cookie Policy from time to time. The "Last updated" date at the top
-          of this page reflects the most recent revision.</p>
-
-        <h2>6. Contact Us</h2>
-        <p>Questions about this Cookie Policy can be sent to
-          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+        <a href="index.html#connect" class="btn btn-primary" style="margin-top:8px;">Contact Media Relations</a>
+        <p style="margin-top:16px; font-size:0.9375rem;">
+          On the contact form, select <strong>"Media &amp; Press"</strong> from the dropdown.
+        </p>
       </div>
     </div>
   </section>

--- a/partner.html
+++ b/partner.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Cookie Policy for The ILS Network — what cookies and similar technologies are used on theILSnetwork.com.">
-  <meta property="og:title" content="Cookie Policy — The ILS Network">
-  <meta property="og:description" content="What cookies and similar technologies are used on theILSnetwork.com.">
+  <meta name="description" content="Partner with The ILS Network — collaborate on events, content, and community initiatives.">
+  <meta property="og:title" content="Partner With Us — The ILS Network">
+  <meta property="og:description" content="Collaborate on events, content, and community initiatives with The ILS Network.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://theILSnetwork.com/cookies.html">
-  <title>Cookie Policy — The ILS Network</title>
+  <meta property="og:url" content="https://theILSnetwork.com/partner.html">
+  <title>Partner With Us — The ILS Network</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -43,53 +43,40 @@
   <!-- ═══ PAGE HEADER ═══ -->
   <header class="page-header">
     <div class="container">
-      <span class="eyebrow">Legal</span>
-      <h1>Cookie Policy</h1>
-      <p class="section-sub">Last updated: July 1, 2026</p>
+      <span class="eyebrow">Partnerships</span>
+      <h1>Partner With Us</h1>
+      <p class="section-sub">Collaborate with a network that spans media, technology, and community building.</p>
     </div>
   </header>
 
-  <!-- ═══ COOKIE POLICY CONTENT ═══ -->
+  <!-- ═══ PARTNER CONTENT ═══ -->
   <section class="section legal">
     <div class="container">
       <div class="legal-content fade-in">
         <p>
-          This Cookie Policy explains how The ILS Network ("we," "us," or "our") uses cookies and
-          similar technologies on theILSnetwork.com (the "Site").
+          The ILS Network works at the intersection of media, technology, community development,
+          and entrepreneurship. We partner with organizations and brands that share our focus on
+          connection, creation, and leadership.
         </p>
 
-        <h2>1. What Are Cookies</h2>
-        <p>Cookies are small text files placed on your device by websites you visit. They're
-          commonly used to make sites work, remember preferences, or gather usage information.</p>
-
-        <h2>2. Cookies We Use</h2>
-        <p>The Site itself does not set any first-party cookies. We do not run analytics,
-          advertising, or tracking scripts.</p>
-
-        <h2>3. Third-Party Cookies</h2>
-        <p>Some third-party services embedded in the Site may set their own cookies or use similar
-          technologies under their own policies, independent of us:</p>
+        <h2>What Partnership Can Look Like</h2>
         <ul>
-          <li><strong>Google Fonts</strong> — loads typefaces from Google's servers, which may
-            involve requests to Google's infrastructure. See
-            <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Google's Cookie Policy</a>.</li>
-          <li><strong>Formspree</strong> — processes contact form submissions and may use cookies
-            as part of that service. See
-            <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">Formspree's Privacy Policy</a>.</li>
+          <li>Co-hosted events, workshops, or masterminds;</li>
+          <li>Media and content collaborations that reach our community; and</li>
+          <li>Sponsorships and cross-promotion with network members.</li>
         </ul>
 
-        <h2>4. Managing Cookies</h2>
-        <p>Most browsers let you block or delete cookies through their settings. Since the Site
-          does not rely on cookies to function, blocking third-party cookies should not affect your
-          ability to browse the Site, though it may affect embedded third-party features.</p>
+        <h2>Who We're Looking For</h2>
+        <p>
+          We're open to conversations with organizations, brands, and individuals whose work
+          aligns with our three pillars — Connect, Create, and Lead. Tell us about your
+          organization and what a partnership might look like, and we'll follow up to discuss fit.
+        </p>
 
-        <h2>5. Changes to This Policy</h2>
-        <p>We may update this Cookie Policy from time to time. The "Last updated" date at the top
-          of this page reflects the most recent revision.</p>
-
-        <h2>6. Contact Us</h2>
-        <p>Questions about this Cookie Policy can be sent to
-          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+        <a href="index.html#connect" class="btn btn-primary" style="margin-top:8px;">Start a Conversation</a>
+        <p style="margin-top:16px; font-size:0.9375rem;">
+          On the contact form, select <strong>"Partnership Inquiry"</strong> from the dropdown.
+        </p>
       </div>
     </div>
   </section>

--- a/privacy.html
+++ b/privacy.html
@@ -162,11 +162,11 @@
           <div class="footer-col">
             <h4>Community</h4>
             <ul>
-              <li><a href="index.html#connect">Join the Network</a></li>
-              <li><a href="index.html#connect">Partner With Us</a></li>
-              <li><a href="index.html#connect">Media &amp; Press</a></li>
-              <li><a href="index.html#connect">Speaking Requests</a></li>
-              <li><a href="index.html#connect">Advertise</a></li>
+              <li><a href="join.html">Join the Network</a></li>
+              <li><a href="partner.html">Partner With Us</a></li>
+              <li><a href="media.html">Media &amp; Press</a></li>
+              <li><a href="speaking.html">Speaking Requests</a></li>
+              <li><a href="advertise.html">Advertise</a></li>
             </ul>
           </div>
           <div class="footer-col">

--- a/speaking.html
+++ b/speaking.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Cookie Policy for The ILS Network — what cookies and similar technologies are used on theILSnetwork.com.">
-  <meta property="og:title" content="Cookie Policy — The ILS Network">
-  <meta property="og:description" content="What cookies and similar technologies are used on theILSnetwork.com.">
+  <meta name="description" content="Invite The ILS Network to speak at your event, panel, or podcast.">
+  <meta property="og:title" content="Speaking Requests — The ILS Network">
+  <meta property="og:description" content="Invite The ILS Network to speak at your event, panel, or podcast.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://theILSnetwork.com/cookies.html">
-  <title>Cookie Policy — The ILS Network</title>
+  <meta property="og:url" content="https://theILSnetwork.com/speaking.html">
+  <title>Speaking Requests — The ILS Network</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
@@ -43,53 +43,38 @@
   <!-- ═══ PAGE HEADER ═══ -->
   <header class="page-header">
     <div class="container">
-      <span class="eyebrow">Legal</span>
-      <h1>Cookie Policy</h1>
-      <p class="section-sub">Last updated: July 1, 2026</p>
+      <span class="eyebrow">Speaking</span>
+      <h1>Speaking Requests</h1>
+      <p class="section-sub">Invite The ILS Network to your event, panel, or podcast.</p>
     </div>
   </header>
 
-  <!-- ═══ COOKIE POLICY CONTENT ═══ -->
+  <!-- ═══ SPEAKING CONTENT ═══ -->
   <section class="section legal">
     <div class="container">
       <div class="legal-content fade-in">
         <p>
-          This Cookie Policy explains how The ILS Network ("we," "us," or "our") uses cookies and
-          similar technologies on theILSnetwork.com (the "Site").
+          The ILS Network speaks on the themes at the center of everything we do — connection,
+          creation, and leadership. We're open to panels, keynotes, workshops, and podcast
+          appearances that fit those themes.
         </p>
 
-        <h2>1. What Are Cookies</h2>
-        <p>Cookies are small text files placed on your device by websites you visit. They're
-          commonly used to make sites work, remember preferences, or gather usage information.</p>
-
-        <h2>2. Cookies We Use</h2>
-        <p>The Site itself does not set any first-party cookies. We do not run analytics,
-          advertising, or tracking scripts.</p>
-
-        <h2>3. Third-Party Cookies</h2>
-        <p>Some third-party services embedded in the Site may set their own cookies or use similar
-          technologies under their own policies, independent of us:</p>
+        <h2>What to Include in Your Request</h2>
         <ul>
-          <li><strong>Google Fonts</strong> — loads typefaces from Google's servers, which may
-            involve requests to Google's infrastructure. See
-            <a href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">Google's Cookie Policy</a>.</li>
-          <li><strong>Formspree</strong> — processes contact form submissions and may use cookies
-            as part of that service. See
-            <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">Formspree's Privacy Policy</a>.</li>
+          <li>Event or show name and date;</li>
+          <li>Audience size and type (in-person, virtual, industry focus); </li>
+          <li>Format — panel, keynote, workshop, or podcast interview; and</li>
+          <li>The topic or theme you'd like us to speak to.</li>
         </ul>
 
-        <h2>4. Managing Cookies</h2>
-        <p>Most browsers let you block or delete cookies through their settings. Since the Site
-          does not rely on cookies to function, blocking third-party cookies should not affect your
-          ability to browse the Site, though it may affect embedded third-party features.</p>
+        <p>
+          Send us the details and we'll follow up to confirm availability and fit.
+        </p>
 
-        <h2>5. Changes to This Policy</h2>
-        <p>We may update this Cookie Policy from time to time. The "Last updated" date at the top
-          of this page reflects the most recent revision.</p>
-
-        <h2>6. Contact Us</h2>
-        <p>Questions about this Cookie Policy can be sent to
-          <a href="mailto:support@theilsnetwork.com">support@theilsnetwork.com</a>.</p>
+        <a href="index.html#connect" class="btn btn-primary" style="margin-top:8px;">Submit a Speaking Request</a>
+        <p style="margin-top:16px; font-size:0.9375rem;">
+          On the contact form, select <strong>"Speaking Request"</strong> from the dropdown.
+        </p>
       </div>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -617,6 +617,10 @@ a:hover { color: var(--accent); }
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+.legal-content a.btn {
+  color: #fff;
+  text-decoration: none;
+}
 
 /* ─── SCROLL ANIMATIONS ─── */
 .fade-in {

--- a/terms.html
+++ b/terms.html
@@ -154,11 +154,11 @@
           <div class="footer-col">
             <h4>Community</h4>
             <ul>
-              <li><a href="index.html#connect">Join the Network</a></li>
-              <li><a href="index.html#connect">Partner With Us</a></li>
-              <li><a href="index.html#connect">Media &amp; Press</a></li>
-              <li><a href="index.html#connect">Speaking Requests</a></li>
-              <li><a href="index.html#connect">Advertise</a></li>
+              <li><a href="join.html">Join the Network</a></li>
+              <li><a href="partner.html">Partner With Us</a></li>
+              <li><a href="media.html">Media &amp; Press</a></li>
+              <li><a href="speaking.html">Speaking Requests</a></li>
+              <li><a href="advertise.html">Advertise</a></li>
             </ul>
           </div>
           <div class="footer-col">


### PR DESCRIPTION
## Summary
- Adds `join.html`, `partner.html`, `media.html`, `speaking.html`, and `advertise.html` — the footer's Community column previously pointed all five labels (Join the Network, Partner With Us, Media & Press, Speaking Requests, Advertise) at the same `#connect` anchor with no distinct content behind any of them.
- Each new page reuses the site's existing nav/footer/`.legal-content` structure and theme, with a short description of the topic and a CTA back to the contact form, including which dropdown option to pick.
- Adds an "Advertising Inquiry" option to the contact form's topic dropdown so the new Advertise page's CTA has a matching option.
- Updates the Community column links across all six existing pages (`index.html`, `privacy.html`, `terms.html`, `cookies.html`, `disclaimer.html`, `accessibility.html`) to point at the new pages.

**Left unchanged:** the Resources column (Newsletter, Events, Podcast, Blog) still points at `#connect` — there's no real content behind these yet (no blog posts, podcast episodes, or events), so per direction, building pages for those is deferred until there's actual content to publish.

## Test plan
- Served the site locally and confirmed all five new pages return 200 and render correctly with the site's existing dark theme, nav, and footer.
- Confirmed the footer's Community links across every page now resolve to real, distinct pages.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BftjSvhM7KKGEXMXuMMoa1)_